### PR TITLE
Revert "gha: replacing jidicula clang format action with cpp-linter"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-          - os: macos-11
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up miniconda
@@ -27,24 +26,22 @@ jobs:
         with:
           python-version: 3.9
           auto-update-conda: false
-          channels: andrsd,conda-forge,defaults
+          channels: andrsd,main
           channel-priority: strict
-          miniforge-version: latest
-          miniforge-variant: Mambaforge
-          use-mamba: true
 
       - name: Checkout source
         uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |
-          mamba install \
+          conda install \
             cmake \
             make \
             flex \
-            cxx-compiler \
+            mpich \
+            mpich-mpicxx \
             python \
-            exodusii==2022.08.01 \
+            exodusii=2022.08.01 \
             fmt==9.1.0 \
             lcov
 

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -9,21 +9,14 @@ on:
       - main
 
 jobs:
-  cpp-linter:
-    name: c++ linter
+  formatting-check:
+    name: Check formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-
-      - uses: cpp-linter/cpp-linter-action@v2
-        id: linter
-        with:
-          style: file
-          version: 14
-          lines-changed-only: true
-          ignore: 'contrib'
-          step-summary: true
-
-      - name: Result
-        if: steps.linter.outputs.checks-failed > 0
-        run: exit 1
+    - uses: actions/checkout@v3
+    - name: Clang-format style check
+      uses: jidicula/clang-format-action@v4.3.0
+      with:
+        clang-format-version: '14'
+        check-path: .
+        exclude-regex: './contrib/'

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -357,7 +357,8 @@ read_gmsh_file(const std::string & file_name)
     const std::vector<gmshparsercpp::MshFile::MultiDEntity> * ents = get_entities_by_dim(f, dim);
     build_element_blocks(el_blk_dim[dim], *ents);
 
-    const std::vector<gmshparsercpp::MshFile::MultiDEntity> * sideset_ents = get_entities_by_dim(f, side_set_dim);
+    const std::vector<gmshparsercpp::MshFile::MultiDEntity> * sideset_ents =
+        get_entities_by_dim(f, side_set_dim);
     build_side_sets(el_blk_dim[side_set_dim], *sideset_ents);
 }
 


### PR DESCRIPTION
This reverts commit 6e6fcfdb9ffcf510f8b16cca0f6a145cea3fe869.
